### PR TITLE
Ignore wildcard matchers in the robots.txt

### DIFF
--- a/app/gemportal.go
+++ b/app/gemportal.go
@@ -172,7 +172,12 @@ func (gp *GemPortal) IsWebProxyAllowed(ctx *Context) bool {
 		gp.robotsCache.Set(ctx.GemURL.Host, robots, cache.DefaultExpiration)
 	}
 
-	return robots.TestAgent(ctx.GemURL.Path, "webproxy")
+	// Is the group EXPLICITLY listed?
+	if group := robots.FindGroup("webproxy"); group.Agent == "webproxy" {
+		return group.Test(ctx.GemURL.Path)
+	} else {
+		return true
+	}
 }
 
 // ServeGemini2HTML handles Gemini2HTML requests

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.18
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.8.1
-	github.com/temoto/robotstxt v1.1.2
+	github.com/temoto/robotstxt v1.1.3-0.20220411224903-a68aeca94fff
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/temoto/robotstxt v1.1.2 h1:W2pOjSJ6SWvldyEuiFXNxz3xZ8aiWX5LbfDiOFd7Fxg=
 github.com/temoto/robotstxt v1.1.2/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
+github.com/temoto/robotstxt v1.1.3-0.20220411224903-a68aeca94fff h1:ihePszykP98CqxtcqQ//u0XYOQyAoFonxh6sVW2xajI=
+github.com/temoto/robotstxt v1.1.3-0.20220411224903-a68aeca94fff/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
 golang.org/x/net v0.0.0-20201216054612-986b41b23924/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=


### PR DESCRIPTION
This allows gemini hosts to address this software in the robots.txt with an explicit `user-agent: webproxy` only.

Closes #12